### PR TITLE
Added Dockerfile and documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM nimlang/nim
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc mingw-w64 xz-utils git
+
+RUN nimble --accept install winim nimcrypto docopt ptr_math strenc
+RUN git clone https://github.com/icyguider/Nimcrypt2.git && \
+        cd Nimcrypt2 && \
+        nim c -d=release --cc:gcc --embedsrc=on --hints=on --app=console --cpu=amd64 --out=nimcrypt nimcrypt.nim
+
+RUN cp /Nimcrypt2/nimcrypt /nimcrypt && \
+        cp /Nimcrypt2/syscalls.nim / && \
+        mkdir pack && cd /
+
+CMD ["./nimcrypt"]

--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ amd64.windows.clang.cpp.linkerexe = "x86_64-w64-mingw32-clang++"
 
 There is probably a better way to do this but this is what worked for me. If you have issues, just keep trying and ensure that you can run `x86_64-w64-mingw32-clang -v` and it shows "Obfuscator-LLVM" in the output. Also ensure MinGW is using the Obfuscator-LLVM library files: Nim will give you an error if not.
 
+#### Usage with Docker
+
+If you run into issues getting the nim toolchain to work on your system, you can build and run nymcrypt inside docker instead.
+
+To build the docker image from a checkout of the git repository:
+```
+docker build -t nimcrypt .
+```
+
+To run nimcrypt inside docker on a binary called `to-pack.exe`:
+```
+docker run -v $PWD:/pack nimcrypt ./nimcrypt -f /pack/to-pack.exe -t pe -o /pack/packed.exe
+```
+
+Here the local directory ($PWD) is assigned the /pack/ directory in the container using a docker volume with `-v`.
+
+
 #### Known Bugs:
 * As [described](https://github.com/S3cur3Th1sSh1t/Nim-RunPE/blob/a117ecec635824703047c1d850607bdf2cfa628b/README.md?plain=1#L13) by ShitSecure, if the release version of mimikatz is loaded via the PE loader, it will not accept commands for some unknown reason. Using a version of mimikatz that was compiled from source fixes this issue.
 


### PR DESCRIPTION
I ran into nim and/or mingw-w64 compiler issues when trying to use this project on Arch linux:

```
{standard input}: Assembler messages:
{standard input}: Error: open SEH entry at end of file (missing .seh_endproc)
Error: execution of an external compiler program '/usr/bin/x86_64-w64-mingw32-gcc -c -w -fmax-errors=3 -mno-ms-bitfields -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -DWIN32_LEAN_AND_MEAN -masm=intel -Os -fno-ident   -I/usr/lib/nim -I/home/olivier/[...]/Nimcrypt2 -o /home/olivier/.cache/nim/stub_r/@m..@s..@s..@s..@s..@s..@s..@susr@slib@snim@ssystem@sassertions.nim.c.o /home/olivier/.cache/nim/stub_r/@m..@s..@s..@s..@s..@s..@s..@susr@slib@snim@ssystem@sassertions.nim.c' failed with exit code: 1

[!] Stub compilation failed! Check stub for errors.
during RTL pass: final
/home/olivier/.cache/nim/stub_r/@m..@s..@s..@s..@s..@s..@s..@susr@slib@snim@ssystem.nim.c: In function ‘raiseOutOfMem__system_3740’:
/home/olivier/.cache/nim/stub_r/@m..@s..@s..@s..@s..@s..@s..@susr@slib@snim@ssystem.nim.c:1039:1: internal compiler error: in seh_emit_stackalloc, at config/i386/winnt.cc:1055
 1039 | }
      | ^
0x19c77e7 internal_error(char const*, ...)
	???:0
0x6738cc fancy_abort(char const*, int, char const*)
	???:0
0xfc88e8 i386_pe_seh_unwind_emit(_IO_FILE*, rtx_insn*)
	???:0
0x8da73b final_scan_insn(rtx_insn*, _IO_FILE*, int, int, int*)
	???:0
Please submit a full bug report, with preprocessed source (by using -freport-bug).
Please include the complete backtrace with any bug report.
See <https://bugs.archlinux.org/> for instructions.
{standard input}: Assembler messages:
{standard input}: Error: open SEH entry at end of file (missing .seh_endproc)
```

I figured this would be hard to understand and fix and I figured that Debian/Ubuntu was probably well-tested and working so a docker container was a good idea.

Usage is documented in the README but in case you want to see it in action:
```
$ docker run -v $PWD:/pack nimcrypt ./nimcrypt -f /pack/to-pack.exe -t pe -o /pack/packed.exe -n -s --no-ppid-spoof
                      ___                                           
                   .-'   `'.                                        
                  /         \                                       
                  |         ;                                       
                  |         |           ___.--,                     
         _.._     |0) ~ (0) |    _.---'`__.-( (_.                   
  __.--'`_.. '.__.\    '--. \_.-' ,.--'`     `""`                   
 ( ,.--'`   ',__ /./;   ;, '.__.'`    __                            
 _`) )  .---.__.' / |   |\   \__..--""  ""'--.,_                    
`---' .'.''-._.-'`_./  /\ '.  \ _.-~~~````~~~-._`-.__.'             
      | |  .' _.-' |  |  \  \  '.               `~---`              
       \ \/ .'     \  \   '. '-._)                                  
        \/ /        \  \    `=.__`~-.   Nimcrypt v2               
   jgs  / /\         `) )    / / `"".`\                             
  , _.-'.'\ \        / /    ( (     / /  3-in-1 C#, PE, & Raw Shellcode Loader
   `--~`   ) )    .-'.'      '.'.  | (                              
          (/`    ( (`          ) )  '-;                             
           `      '-;         (-'                                   

[+] NimlineWhispers2 enabled
[+] String encryption disabled
[+] Sandbox checks disabled
[+] Unhooking ntdll.dll disabled
[+] Verbose messages disabled
[+] Syscall name randomization disabled
Hint: used config file '/nim/config/nim.cfg' [Conf]
Hint: used config file '/nim/config/config.nims' [Conf]
.....................................................................................................................................................................................
/stub.nim(13, 8) Warning: imported and not used: 'os' [UnusedImport]
/stub.nim(11, 8) Warning: imported and not used: 'random' [UnusedImport]
/stub.nim(10, 8) Warning: imported and not used: 'strutils' [UnusedImport]
/stub.nim(12, 8) Warning: imported and not used: 'times' [UnusedImport]
CC: nim/lib/std/private/digitsutils.nim
CC: nim/lib/system/assertions.nim
CC: nim/lib/system/formatfloat.nim
CC: nim/lib/system/dollars.nim
CC: nim/lib/system/io.nim
CC: nim/lib/system.nim
CC: root/.nimble/pkgs/winim-3.9.0/winim/inc/winbase.nim
CC: nim/lib/pure/parseutils.nim
CC: nim/lib/pure/unicode.nim
CC: nim/lib/pure/strutils.nim
CC: root/.nimble/pkgs/winim-3.9.0/winim/winstr.nim
CC: root/.nimble/pkgs/ptr_math-0.3.0/ptr_math.nim
CC: root/.nimble/pkgs/nimcrypto-0.5.4/nimcrypto/utils.nim
CC: root/.nimble/pkgs/nimcrypto-0.5.4/nimcrypto/hash.nim
CC: root/.nimble/pkgs/nimcrypto-0.5.4/nimcrypto/sha2.nim
CC: root/.nimble/pkgs/nimcrypto-0.5.4/nimcrypto/rijndael.nim
CC: root/.nimble/pkgs/nimcrypto-0.5.4/nimcrypto/bcmode.nim
CC: nim/lib/pure/dynlib.nim
CC: nim/lib/windows/winlean.nim
CC: nim/lib/pure/times.nim
CC: nim/lib/std/private/win_setenv.nim
CC: nim/lib/pure/os.nim
CC: root/.nimble/pkgs/nimcrypto-0.5.4/nimcrypto/sysrand.nim
CC: nim/lib/pure/base64.nim
CC: nim/lib/pure/strformat.nim
CC: nim/lib/pure/random.nim
CC: stub.nim
Hint:  [Link]
Hint: gc: refc; opt: size; options: -d:release
1264382 lines; 6.620s; 348.664MiB peakmem; proj: /stub.nim; out: /pack/packed.exe [SuccessX]

[+] Stub compiled successfully as /pack/packed.exe
```

Let me know if you have any questions.